### PR TITLE
Fix repeated attack after success

### DIFF
--- a/Assets/Game/Scripts/Pieces/AttackPiece.cs
+++ b/Assets/Game/Scripts/Pieces/AttackPiece.cs
@@ -44,7 +44,8 @@ public class AttackPiece : InteractivePiece
     private void Sucess()
     {
         EndAttack();
-        SendMessage("NewTarget");
+        var mover = GetComponent<MovePiece>();
+        mover?.NewTarget();
     }
 
     private void Failed()


### PR DESCRIPTION
## Summary
- replace SendMessage call with direct MovePiece target update to avoid triggering a second attack

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fe897ab748320b1ba16a2bf54fdd9